### PR TITLE
Fixing the color of the sidebar-toggle for "lanyon_subtheme"

### DIFF
--- a/v7/lanyon/assets/css/lanyon.css
+++ b/v7/lanyon/assets/css/lanyon.css
@@ -447,6 +447,7 @@ a.pagination-item:hover {
 /* Red */
 .theme-base-08 .sidebar,
 .theme-base-08 .sidebar-toggle:active,
+.theme-base-08 #sidebar-checkbox:focus ~ .sidebar-toggle,
 .theme-base-08 #sidebar-checkbox:checked ~ .sidebar-toggle {
   background-color: #ac4142;
 }
@@ -455,10 +456,25 @@ a.pagination-item:hover {
 .theme-base-08 .related-posts li a:hover {
   color: #ac4142;
 }
+.theme-base-08 .sidebar-toggle:before {
+  background-image: -webkit-linear-gradient(to bottom, #ac4142, #ac4142 20%, #fff 20%, #fff 40%, #ac4142 40%, #ac4142 60%, #fff 60%, #fff 80%, #ac4142 80%, #ac4142 100%);
+  background-image: -moz-linear-gradient(to bottom, #ac4142, #ac4142 20%, #fff 20%, #fff 40%, #ac4142 40%, #ac4142 60%, #fff 60%, #fff 80%, #ac4142 80%, #ac4142 100%);
+  background-image: -ms-linear-gradient(to bottom, #ac4142, #ac4142 20%, #fff 20%, #fff 40%, #ac4142 40%, #ac4142 60%, #fff 60%, #fff 80%, #ac4142 80%, #ac4142 100%);
+  background-image: linear-gradient(to bottom, #ac4142, #ac4142 20%, #fff 20%, #fff 40%, #ac4142 40%, #ac4142 60%, #fff 60%, #fff 80%, #ac4142 80%, #ac4142 100%);
+}
+.theme-base-08 .sidebar-toggle:active:before,
+.theme-base-08 #sidebar-checkbox:focus ~ .sidebar-toggle:before,
+.theme-base-08 #sidebar-checkbox:checked ~ .sidebar-toggle:before {
+  background-image: -webkit-linear-gradient(to bottom, #fff, #fff 20%, #ac4142 20%, #ac4142 40%, #fff 40%, #fff 60%, #ac4142 60%, #ac4142 80%, #fff 80%, #fff 100%);
+  background-image: -moz-linear-gradient(to bottom, #fff, #fff 20%, #ac4142 20%, #ac4142 40%, #fff 40%, #fff 60%, #ac4142 60%, #ac4142 80%, #fff 80%, #fff 100%);
+  background-image: -ms-linear-gradient(to bottom, #fff, #fff 20%, #ac4142 20%, #ac4142 40%, #fff 40%, #fff 60%, #ac4142 60%, #ac4142 80%, #fff 80%, #fff 100%);
+  background-image: linear-gradient(to bottom, #fff, #fff 20%, #ac4142 20%, #ac4142 40%, #fff 40%, #fff 60%, #ac4142 60%, #ac4142 80%, #fff 80%, #fff 100%);
+}
 
 /* Orange */
 .theme-base-09 .sidebar,
 .theme-base-09 .sidebar-toggle:active,
+.theme-base-09 #sidebar-checkbox:focus ~ .sidebar-toggle,
 .theme-base-09 #sidebar-checkbox:checked ~ .sidebar-toggle {
   background-color: #d28445;
 }
@@ -467,10 +483,25 @@ a.pagination-item:hover {
 .theme-base-09 .related-posts li a:hover {
   color: #d28445;
 }
+.theme-base-09 .sidebar-toggle:before {
+  background-image: -webkit-linear-gradient(to bottom, #d28445, #d28445 20%, #fff 20%, #fff 40%, #d28445 40%, #d28445 60%, #fff 60%, #fff 80%, #d28445 80%, #d28445 100%);
+  background-image: -moz-linear-gradient(to bottom, #d28445, #d28445 20%, #fff 20%, #fff 40%, #d28445 40%, #d28445 60%, #fff 60%, #fff 80%, #d28445 80%, #d28445 100%);
+  background-image: -ms-linear-gradient(to bottom, #d28445, #d28445 20%, #fff 20%, #fff 40%, #d28445 40%, #d28445 60%, #fff 60%, #fff 80%, #d28445 80%, #d28445 100%);
+  background-image: linear-gradient(to bottom, #d28445, #d28445 20%, #fff 20%, #fff 40%, #d28445 40%, #d28445 60%, #fff 60%, #fff 80%, #d28445 80%, #d28445 100%);
+}
+.theme-base-09 .sidebar-toggle:active:before,
+.theme-base-09 #sidebar-checkbox:focus ~ .sidebar-toggle:before,
+.theme-base-09 #sidebar-checkbox:checked ~ .sidebar-toggle:before {
+  background-image: -webkit-linear-gradient(to bottom, #fff, #fff 20%, #d28445 20%, #d28445 40%, #fff 40%, #fff 60%, #d28445 60%, #d28445 80%, #fff 80%, #fff 100%);
+  background-image: -moz-linear-gradient(to bottom, #fff, #fff 20%, #d28445 20%, #d28445 40%, #fff 40%, #fff 60%, #d28445 60%, #d28445 80%, #fff 80%, #fff 100%);
+  background-image: -ms-linear-gradient(to bottom, #fff, #fff 20%, #d28445 20%, #d28445 40%, #fff 40%, #fff 60%, #d28445 60%, #d28445 80%, #fff 80%, #fff 100%);
+  background-image: linear-gradient(to bottom, #fff, #fff 20%, #d28445 20%, #d28445 40%, #fff 40%, #fff 60%, #d28445 60%, #d28445 80%, #fff 80%, #fff 100%);
+}
 
 /* Yellow */
 .theme-base-0a .sidebar,
 .theme-base-0a .sidebar-toggle:active,
+.theme-base-0a #sidebar-checkbox:focus ~ .sidebar-toggle,
 .theme-base-0a #sidebar-checkbox:checked ~ .sidebar-toggle {
   background-color: #f4bf75;
 }
@@ -479,10 +510,25 @@ a.pagination-item:hover {
 .theme-base-0a .related-posts li a:hover {
   color: #f4bf75;
 }
+.theme-base-0a .sidebar-toggle:before {
+  background-image: -webkit-linear-gradient(to bottom, #f4bf75, #f4bf75 20%, #fff 20%, #fff 40%, #f4bf75 40%, #f4bf75 60%, #fff 60%, #fff 80%, #f4bf75 80%, #f4bf75 100%);
+  background-image: -moz-linear-gradient(to bottom, #f4bf75, #f4bf75 20%, #fff 20%, #fff 40%, #f4bf75 40%, #f4bf75 60%, #fff 60%, #fff 80%, #f4bf75 80%, #f4bf75 100%);
+  background-image: -ms-linear-gradient(to bottom, #f4bf75, #f4bf75 20%, #fff 20%, #fff 40%, #f4bf75 40%, #f4bf75 60%, #fff 60%, #fff 80%, #f4bf75 80%, #f4bf75 100%);
+  background-image: linear-gradient(to bottom, #f4bf75, #f4bf75 20%, #fff 20%, #fff 40%, #f4bf75 40%, #f4bf75 60%, #fff 60%, #fff 80%, #f4bf75 80%, #f4bf75 100%);
+}
+.theme-base-0a .sidebar-toggle:active:before,
+.theme-base-0a #sidebar-checkbox:focus ~ .sidebar-toggle:before,
+.theme-base-0a #sidebar-checkbox:checked ~ .sidebar-toggle:before {
+  background-image: -webkit-linear-gradient(to bottom, #fff, #fff 20%, #f4bf75 20%, #f4bf75 40%, #fff 40%, #fff 60%, #f4bf75 60%, #f4bf75 80%, #fff 80%, #fff 100%);
+  background-image: -moz-linear-gradient(to bottom, #fff, #fff 20%, #f4bf75 20%, #f4bf75 40%, #fff 40%, #fff 60%, #f4bf75 60%, #f4bf75 80%, #fff 80%, #fff 100%);
+  background-image: -ms-linear-gradient(to bottom, #fff, #fff 20%, #f4bf75 20%, #f4bf75 40%, #fff 40%, #fff 60%, #f4bf75 60%, #f4bf75 80%, #fff 80%, #fff 100%);
+  background-image: linear-gradient(to bottom, #fff, #fff 20%, #f4bf75 20%, #f4bf75 40%, #fff 40%, #fff 60%, #f4bf75 60%, #f4bf75 80%, #fff 80%, #fff 100%);
+}
 
 /* Green */
 .theme-base-0b .sidebar,
 .theme-base-0b .sidebar-toggle:active,
+.theme-base-0b #sidebar-checkbox:focus ~ .sidebar-toggle,
 .theme-base-0b #sidebar-checkbox:checked ~ .sidebar-toggle {
   background-color: #90a959;
 }
@@ -491,10 +537,25 @@ a.pagination-item:hover {
 .theme-base-0b .related-posts li a:hover {
   color: #90a959;
 }
+.theme-base-0b .sidebar-toggle:before {
+  background-image: -webkit-linear-gradient(to bottom, #90a959, #90a959 20%, #fff 20%, #fff 40%, #90a959 40%, #90a959 60%, #fff 60%, #fff 80%, #90a959 80%, #90a959 100%);
+  background-image: -moz-linear-gradient(to bottom, #90a959, #90a959 20%, #fff 20%, #fff 40%, #90a959 40%, #90a959 60%, #fff 60%, #fff 80%, #90a959 80%, #90a959 100%);
+  background-image: -ms-linear-gradient(to bottom, #90a959, #90a959 20%, #fff 20%, #fff 40%, #90a959 40%, #90a959 60%, #fff 60%, #fff 80%, #90a959 80%, #90a959 100%);
+  background-image: linear-gradient(to bottom, #90a959, #90a959 20%, #fff 20%, #fff 40%, #90a959 40%, #90a959 60%, #fff 60%, #fff 80%, #90a959 80%, #90a959 100%);
+}
+.theme-base-0b .sidebar-toggle:active:before,
+.theme-base-0b #sidebar-checkbox:focus ~ .sidebar-toggle:before,
+.theme-base-0b #sidebar-checkbox:checked ~ .sidebar-toggle:before {
+  background-image: -webkit-linear-gradient(to bottom, #fff, #fff 20%, #90a959 20%, #90a959 40%, #fff 40%, #fff 60%, #90a959 60%, #90a959 80%, #fff 80%, #fff 100%);
+  background-image: -moz-linear-gradient(to bottom, #fff, #fff 20%, #90a959 20%, #90a959 40%, #fff 40%, #fff 60%, #90a959 60%, #90a959 80%, #fff 80%, #fff 100%);
+  background-image: -ms-linear-gradient(to bottom, #fff, #fff 20%, #90a959 20%, #90a959 40%, #fff 40%, #fff 60%, #90a959 60%, #90a959 80%, #fff 80%, #fff 100%);
+  background-image: linear-gradient(to bottom, #fff, #fff 20%, #90a959 20%, #90a959 40%, #fff 40%, #fff 60%, #90a959 60%, #90a959 80%, #fff 80%, #fff 100%);
+}
 
 /* Cyan */
 .theme-base-0c .sidebar,
 .theme-base-0c .sidebar-toggle:active,
+.theme-base-0c #sidebar-checkbox:focus ~ .sidebar-toggle,
 .theme-base-0c #sidebar-checkbox:checked ~ .sidebar-toggle {
   background-color: #75b5aa;
 }
@@ -503,10 +564,25 @@ a.pagination-item:hover {
 .theme-base-0c .related-posts li a:hover {
   color: #75b5aa;
 }
+.theme-base-0c .sidebar-toggle:before {
+  background-image: -webkit-linear-gradient(to bottom, #75b5aa, #75b5aa 20%, #fff 20%, #fff 40%, #75b5aa 40%, #75b5aa 60%, #fff 60%, #fff 80%, #75b5aa 80%, #75b5aa 100%);
+  background-image: -moz-linear-gradient(to bottom, #75b5aa, #75b5aa 20%, #fff 20%, #fff 40%, #75b5aa 40%, #75b5aa 60%, #fff 60%, #fff 80%, #75b5aa 80%, #75b5aa 100%);
+  background-image: -ms-linear-gradient(to bottom, #75b5aa, #75b5aa 20%, #fff 20%, #fff 40%, #75b5aa 40%, #75b5aa 60%, #fff 60%, #fff 80%, #75b5aa 80%, #75b5aa 100%);
+  background-image: linear-gradient(to bottom, #75b5aa, #75b5aa 20%, #fff 20%, #fff 40%, #75b5aa 40%, #75b5aa 60%, #fff 60%, #fff 80%, #75b5aa 80%, #75b5aa 100%);
+}
+.theme-base-0c .sidebar-toggle:active:before,
+.theme-base-0c #sidebar-checkbox:focus ~ .sidebar-toggle:before,
+.theme-base-0c #sidebar-checkbox:checked ~ .sidebar-toggle:before {
+  background-image: -webkit-linear-gradient(to bottom, #fff, #fff 20%, #75b5aa 20%, #75b5aa 40%, #fff 40%, #fff 60%, #75b5aa 60%, #75b5aa 80%, #fff 80%, #fff 100%);
+  background-image: -moz-linear-gradient(to bottom, #fff, #fff 20%, #75b5aa 20%, #75b5aa 40%, #fff 40%, #fff 60%, #75b5aa 60%, #75b5aa 80%, #fff 80%, #fff 100%);
+  background-image: -ms-linear-gradient(to bottom, #fff, #fff 20%, #75b5aa 20%, #75b5aa 40%, #fff 40%, #fff 60%, #75b5aa 60%, #75b5aa 80%, #fff 80%, #fff 100%);
+  background-image: linear-gradient(to bottom, #fff, #fff 20%, #75b5aa 20%, #75b5aa 40%, #fff 40%, #fff 60%, #75b5aa 60%, #75b5aa 80%, #fff 80%, #fff 100%);
+}
 
 /* Blue */
 .theme-base-0d .sidebar,
 .theme-base-0d .sidebar-toggle:active,
+.theme-base-0d #sidebar-checkbox:focus ~ .sidebar-toggle,
 .theme-base-0d #sidebar-checkbox:checked ~ .sidebar-toggle {
   background-color: #6a9fb5;
 }
@@ -515,10 +591,25 @@ a.pagination-item:hover {
 .theme-base-0d .related-posts li a:hover {
   color: #6a9fb5;
 }
+.theme-base-0d .sidebar-toggle:before {
+  background-image: -webkit-linear-gradient(to bottom, #6a9fb5, #6a9fb5 20%, #fff 20%, #fff 40%, #6a9fb5 40%, #6a9fb5 60%, #fff 60%, #fff 80%, #6a9fb5 80%, #6a9fb5 100%);
+  background-image: -moz-linear-gradient(to bottom, #6a9fb5, #6a9fb5 20%, #fff 20%, #fff 40%, #6a9fb5 40%, #6a9fb5 60%, #fff 60%, #fff 80%, #6a9fb5 80%, #6a9fb5 100%);
+  background-image: -ms-linear-gradient(to bottom, #6a9fb5, #6a9fb5 20%, #fff 20%, #fff 40%, #6a9fb5 40%, #6a9fb5 60%, #fff 60%, #fff 80%, #6a9fb5 80%, #6a9fb5 100%);
+  background-image: linear-gradient(to bottom, #6a9fb5, #6a9fb5 20%, #fff 20%, #fff 40%, #6a9fb5 40%, #6a9fb5 60%, #fff 60%, #fff 80%, #6a9fb5 80%, #6a9fb5 100%);
+}
+.theme-base-0d .sidebar-toggle:active:before,
+.theme-base-0d #sidebar-checkbox:focus ~ .sidebar-toggle:before,
+.theme-base-0d #sidebar-checkbox:checked ~ .sidebar-toggle:before {
+  background-image: -webkit-linear-gradient(to bottom, #fff, #fff 20%, #6a9fb5 20%, #6a9fb5 40%, #fff 40%, #fff 60%, #6a9fb5 60%, #6a9fb5 80%, #fff 80%, #fff 100%);
+  background-image: -moz-linear-gradient(to bottom, #fff, #fff 20%, #6a9fb5 20%, #6a9fb5 40%, #fff 40%, #fff 60%, #6a9fb5 60%, #6a9fb5 80%, #fff 80%, #fff 100%);
+  background-image: -ms-linear-gradient(to bottom, #fff, #fff 20%, #6a9fb5 20%, #6a9fb5 40%, #fff 40%, #fff 60%, #6a9fb5 60%, #6a9fb5 80%, #fff 80%, #fff 100%);
+  background-image: linear-gradient(to bottom, #fff, #fff 20%, #6a9fb5 20%, #6a9fb5 40%, #fff 40%, #fff 60%, #6a9fb5 60%, #6a9fb5 80%, #fff 80%, #fff 100%);
+}
 
 /* Magenta */
 .theme-base-0e .sidebar,
 .theme-base-0e .sidebar-toggle:active,
+.theme-base-0e #sidebar-checkbox:focus ~ .sidebar-toggle,
 .theme-base-0e #sidebar-checkbox:checked ~ .sidebar-toggle {
   background-color: #aa759f;
 }
@@ -527,10 +618,25 @@ a.pagination-item:hover {
 .theme-base-0e .related-posts li a:hover {
   color: #aa759f;
 }
+.theme-base-0e .sidebar-toggle:before {
+  background-image: -webkit-linear-gradient(to bottom, #aa759f, #aa759f 20%, #fff 20%, #fff 40%, #aa759f 40%, #aa759f 60%, #fff 60%, #fff 80%, #aa759f 80%, #aa759f 100%);
+  background-image: -moz-linear-gradient(to bottom, #aa759f, #aa759f 20%, #fff 20%, #fff 40%, #aa759f 40%, #aa759f 60%, #fff 60%, #fff 80%, #aa759f 80%, #aa759f 100%);
+  background-image: -ms-linear-gradient(to bottom, #aa759f, #aa759f 20%, #fff 20%, #fff 40%, #aa759f 40%, #aa759f 60%, #fff 60%, #fff 80%, #aa759f 80%, #aa759f 100%);
+  background-image: linear-gradient(to bottom, #aa759f, #aa759f 20%, #fff 20%, #fff 40%, #aa759f 40%, #aa759f 60%, #fff 60%, #fff 80%, #aa759f 80%, #aa759f 100%);
+}
+.theme-base-0e .sidebar-toggle:active:before,
+.theme-base-0e #sidebar-checkbox:focus ~ .sidebar-toggle:before,
+.theme-base-0e #sidebar-checkbox:checked ~ .sidebar-toggle:before {
+  background-image: -webkit-linear-gradient(to bottom, #fff, #fff 20%, #6a9fb5 20%, #aa759f 40%, #fff 40%, #fff 60%, #aa759f 60%, #aa759f 80%, #fff 80%, #fff 100%);
+  background-image: -moz-linear-gradient(to bottom, #fff, #fff 20%, #aa759f 20%, #aa759f 40%, #fff 40%, #fff 60%, #aa759f 60%, #aa759f 80%, #fff 80%, #fff 100%);
+  background-image: -ms-linear-gradient(to bottom, #fff, #fff 20%, #aa759f 20%, #aa759f 40%, #fff 40%, #fff 60%, #aa759f 60%, #aa759f 80%, #fff 80%, #fff 100%);
+  background-image: linear-gradient(to bottom, #fff, #fff 20%, #aa759f 20%, #aa759f 40%, #fff 40%, #fff 60%, #aa759f 60%, #aa759f 80%, #fff 80%, #fff 100%);
+}
 
 /* Brown */
 .theme-base-0f .sidebar,
 .theme-base-0f .sidebar-toggle:active,
+.theme-base-0f #sidebar-checkbox:focus ~ .sidebar-toggle,
 .theme-base-0f #sidebar-checkbox:checked ~ .sidebar-toggle {
   background-color: #8f5536;
 }
@@ -538,6 +644,20 @@ a.pagination-item:hover {
 .theme-base-0f .sidebar-toggle,
 .theme-base-0f .related-posts li a:hover {
   color: #8f5536;
+}
+.theme-base-0f .sidebar-toggle:before {
+  background-image: -webkit-linear-gradient(to bottom, #8f5536, #8f5536 20%, #fff 20%, #fff 40%, #8f5536 40%, #8f5536 60%, #fff 60%, #fff 80%, #8f5536 80%, #8f5536 100%);
+  background-image: -moz-linear-gradient(to bottom, #8f5536, #8f5536 20%, #fff 20%, #fff 40%, #8f5536 40%, #8f5536 60%, #fff 60%, #fff 80%, #8f5536 80%, #8f5536 100%);
+  background-image: -ms-linear-gradient(to bottom, #8f5536, #8f5536 20%, #fff 20%, #fff 40%, #8f5536 40%, #8f5536 60%, #fff 60%, #fff 80%, #8f5536 80%, #8f5536 100%);
+  background-image: linear-gradient(to bottom, #8f5536, #8f5536 20%, #fff 20%, #fff 40%, #8f5536 40%, #8f5536 60%, #fff 60%, #fff 80%, #8f5536 80%, #8f5536 100%);
+}
+.theme-base-0f .sidebar-toggle:active:before,
+.theme-base-0f #sidebar-checkbox:focus ~ .sidebar-toggle:before,
+.theme-base-0f #sidebar-checkbox:checked ~ .sidebar-toggle:before {
+  background-image: -webkit-linear-gradient(to bottom, #fff, #fff 20%, #6a9fb5 20%, #8f5536 40%, #fff 40%, #fff 60%, #8f5536 60%, #8f5536 80%, #fff 80%, #fff 100%);
+  background-image: -moz-linear-gradient(to bottom, #fff, #fff 20%, #8f5536 20%, #8f5536 40%, #fff 40%, #fff 60%, #8f5536 60%, #8f5536 80%, #fff 80%, #fff 100%);
+  background-image: -ms-linear-gradient(to bottom, #fff, #fff 20%, #8f5536 20%, #8f5536 40%, #fff 40%, #fff 60%, #8f5536 60%, #8f5536 80%, #fff 80%, #fff 100%);
+  background-image: linear-gradient(to bottom, #fff, #fff 20%, #8f5536 20%, #8f5536 40%, #fff 40%, #fff 60%, #8f5536 60%, #8f5536 80%, #fff 80%, #fff 100%);
 }
 
 

--- a/v7/lanyon/assets/css/lanyon.css
+++ b/v7/lanyon/assets/css/lanyon.css
@@ -627,7 +627,7 @@ a.pagination-item:hover {
 .theme-base-0e .sidebar-toggle:active:before,
 .theme-base-0e #sidebar-checkbox:focus ~ .sidebar-toggle:before,
 .theme-base-0e #sidebar-checkbox:checked ~ .sidebar-toggle:before {
-  background-image: -webkit-linear-gradient(to bottom, #fff, #fff 20%, #6a9fb5 20%, #aa759f 40%, #fff 40%, #fff 60%, #aa759f 60%, #aa759f 80%, #fff 80%, #fff 100%);
+  background-image: -webkit-linear-gradient(to bottom, #fff, #fff 20%, #aa759f 20%, #aa759f 40%, #fff 40%, #fff 60%, #aa759f 60%, #aa759f 80%, #fff 80%, #fff 100%);
   background-image: -moz-linear-gradient(to bottom, #fff, #fff 20%, #aa759f 20%, #aa759f 40%, #fff 40%, #fff 60%, #aa759f 60%, #aa759f 80%, #fff 80%, #fff 100%);
   background-image: -ms-linear-gradient(to bottom, #fff, #fff 20%, #aa759f 20%, #aa759f 40%, #fff 40%, #fff 60%, #aa759f 60%, #aa759f 80%, #fff 80%, #fff 100%);
   background-image: linear-gradient(to bottom, #fff, #fff 20%, #aa759f 20%, #aa759f 40%, #fff 40%, #fff 60%, #aa759f 60%, #aa759f 80%, #fff 80%, #fff 100%);
@@ -654,7 +654,7 @@ a.pagination-item:hover {
 .theme-base-0f .sidebar-toggle:active:before,
 .theme-base-0f #sidebar-checkbox:focus ~ .sidebar-toggle:before,
 .theme-base-0f #sidebar-checkbox:checked ~ .sidebar-toggle:before {
-  background-image: -webkit-linear-gradient(to bottom, #fff, #fff 20%, #6a9fb5 20%, #8f5536 40%, #fff 40%, #fff 60%, #8f5536 60%, #8f5536 80%, #fff 80%, #fff 100%);
+  background-image: -webkit-linear-gradient(to bottom, #fff, #fff 20%, #8f5536 20%, #8f5536 40%, #fff 40%, #fff 60%, #8f5536 60%, #8f5536 80%, #fff 80%, #fff 100%);
   background-image: -moz-linear-gradient(to bottom, #fff, #fff 20%, #8f5536 20%, #8f5536 40%, #fff 40%, #fff 60%, #8f5536 60%, #8f5536 80%, #fff 80%, #fff 100%);
   background-image: -ms-linear-gradient(to bottom, #fff, #fff 20%, #8f5536 20%, #8f5536 40%, #fff 40%, #fff 60%, #8f5536 60%, #8f5536 80%, #fff 80%, #fff 100%);
   background-image: linear-gradient(to bottom, #fff, #fff 20%, #8f5536 20%, #8f5536 40%, #fff 40%, #fff 60%, #8f5536 60%, #8f5536 80%, #fff 80%, #fff 100%);


### PR DESCRIPTION
When using the GLOBAL_CONTEXT = { "lanyon_subtheme": "theme-base-0X" } to change the color scheme of the lanyon theme, the sidebar-toggle in the top left corner isn't correctly affected by those changes. This is not only inconsistent, it also leads to the toggles colors becoming messy when the sidebar is toggled:
![nikola_lanyon_css_bug](https://cloud.githubusercontent.com/assets/1872304/8594845/3a3b52b8-2645-11e5-8b39-970b2a885ed4.png)

This PR fixes these errors so that the sidebar-toggle is always colored correctly, honoring the "lanyon_subtheme" key:
![nikola_lanyon_css_fix](https://cloud.githubusercontent.com/assets/1872304/8595029/0cc5cd34-2647-11e5-87fe-4c00428e40f6.png)
