### PR TITLE
Update base_helper.tmpl

### DIFF
--- a/v7/bootstrap3-gradients/templates/base_helper.tmpl
+++ b/v7/bootstrap3-gradients/templates/base_helper.tmpl
@@ -132,21 +132,21 @@ lang="${lang}">
 <%def name="html_navigation_links()">
     %for url, text in navigation_links[lang]:
         % if isinstance(url, tuple):
-            <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">${text} <b class="caret"></b></a>
+            <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">${text|h} <b class="caret"></b></a>
             <ul class="dropdown-menu">
             %for suburl, text in url:
                 % if rel_link(permalink, suburl) == "#":
-                    <li class="active"><a href="${permalink}">${text} <span class="sr-only">${messages("(active)", lang)}</span></a>
+                    <li class="active"><a href="${permalink}">${text|h} <span class="sr-only">${messages("(active)", lang)}</span></a>
                 %else:
-                    <li><a href="${suburl}">${text}</a>
+                    <li><a href="${suburl}">${text|h}</a>
                 %endif
             %endfor
             </ul>
         % else:
             % if rel_link(permalink, url) == "#":
-                <li class="active"><a href="${permalink}">${text} <span class="sr-only">${messages("(active)", lang)}</span></a>
+                <li class="active"><a href="${permalink}">${text|h} <span class="sr-only">${messages("(active)", lang)}</span></a>
             %else:
-                <li><a href="${url}">${text}</a>
+                <li><a href="${url}">${text|h}</a>
             %endif
         % endif
     %endfor


### PR DESCRIPTION
Like #57, but for Mako. Brings `base_helper.tmpl` in bootstrap3-gradients up to speed with latest `base_helper.tmpl` in bootstrap3.