### PR TITLE
Fixes python3 compatibility issue mentioned in #64

### DIFF
--- a/v7/material-theme/templates/base_helper.tmpl
+++ b/v7/material-theme/templates/base_helper.tmpl
@@ -112,7 +112,7 @@ lang="{{ lang }}">
                 var links = [
                     {% for item in social_links %}
                         {
-                        {% for k,v in item.iteritems() %}
+                        {% for k,v in item.items() %}
                             "{{ k }}": "{{ v }}",
                         {% endfor %}
                         },


### PR DESCRIPTION
base_helper.tmpl uses ``.iteritems()`` to iterate thru the ``social_links`` list.
But ``.iteritems()`` is not available in python3 
``.items()`` works for both python2 and 3