### PR TITLE
Swap poole.css and lanyon.css in lanyon theme

### DIFF
--- a/v7/lanyon/assets/css/lanyon.css
+++ b/v7/lanyon/assets/css/lanyon.css
@@ -159,7 +159,7 @@ div.sidebar,.sidebar {
           transition: all .3s ease-in-out;
 }
 @media (min-width: 30em) {
-  .sidebar {
+  div.sidebar {
     font-size: .75rem; /* 14px */
   }
 }

--- a/v7/lanyon/bundles
+++ b/v7/lanyon/bundles
@@ -1,1 +1,1 @@
-assets/css/all.css=rst.css,code.css,lanyon.css,poole.css
+assets/css/all.css=rst.css,code.css,poole.css,lanyon.css


### PR DESCRIPTION
With poole.css listed after lanyon.css, the general styles in poole end up overriding the specific ones in lanyon, causing display glitches. This commit switches them.