### PR TITLE
Fix #80

### DIFF
--- a/v7/lanyon/assets/css/lanyon.css
+++ b/v7/lanyon/assets/css/lanyon.css
@@ -205,11 +205,7 @@ a.sidebar-nav-item:focus {
 
 /* Hide the sidebar checkbox that we toggle with `.sidebar-toggle` */
 .sidebar-checkbox {
-  position: absolute;
-  opacity: 0;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-          user-select: none;
+  display: none;
 }
 
 /* Style the `label` that we use to target the `.sidebar-checkbox` */


### PR DESCRIPTION
Fixes 2 issues.
1. When sidebar is clicked, page is scrolled to top and opened: #80 
2. When sidebar is closed, the background color for the bar is still active.