### PR TITLE
Add support for USE_CDN, momentjs and fancydates. Fixes #84

### DIFF
--- a/v7/lanyon/README.md
+++ b/v7/lanyon/README.md
@@ -20,4 +20,3 @@ Known Issues:
 * Not all features of Nikola are tested.
 * Galleries will work better when [Issue #1764](https://github.com/getnikola/nikola/issues/1764) is fixed.
 * Submenus in navigation links are not supported
-* CDNs are not used regardless of ``USE_CDN``

--- a/v7/lanyon/bundles
+++ b/v7/lanyon/bundles
@@ -1,1 +1,3 @@
 assets/css/all.css=rst.css,code.css,poole.css,lanyon.css
+assets/js/all-nocdn.js=jquery.min.js,moment-with-locales.min.js,fancydates.js
+assets/js/all.js=moment-with-locales.min.js,fancydates.js

--- a/v7/lanyon/templates/base.tmpl
+++ b/v7/lanyon/templates/base.tmpl
@@ -47,6 +47,12 @@ ${template_hooks['extra_head']()}
     ${body_end}
     ${template_hooks['body_end']()}
     ${base.late_load_js()}
+    <!-- fancy dates -->
+    <script>
+    moment.locale("${momentjs_locales[lang]}");
+    fancydates(${date_fanciness}, ${js_date_format});
+    </script>
+    <!-- end fancy dates -->
     <%block name="extra_js"></%block>
 </body>
 </html>

--- a/v7/lanyon/templates/base_helper.tmpl
+++ b/v7/lanyon/templates/base_helper.tmpl
@@ -61,6 +61,22 @@ lang="${lang}">
 </%def>
 
 <%def name="late_load_js()">
+    %if use_bundles:
+        %if use_cdn:
+            <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+            <script src="/assets/js/all.js"></script>
+        %else:
+            <script src="/assets/js/all-nocdn.js"></script>
+        %endif
+    %else:
+        %if use_cdn:
+            <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+        %else:
+            <script src="/assets/js/jquery.min.js"></script>
+        %endif
+        <script src="/assets/js/moment-with-locales.min.js"></script>
+        <script src="/assets/js/fancydates.js"></script>
+    %endif
     ${social_buttons_code}
 </%def>
 


### PR DESCRIPTION
Made the following changes:
1. Check for `bundles` and `use_cdn` and use `js` files accordingly.
2. Make changes to `bundles` file as per `cdn` value.
3. Add support for `moment.js` and `fancydates`

Fixes #84 