### PR TITLE
Screenshots with PhantomJS

### DIFF
--- a/scripts/build_themes.py
+++ b/scripts/build_themes.py
@@ -65,8 +65,7 @@ def build_theme(theme=None):
                 shutil.move(os.path.join(tmpdir, 'git-bkp'), os.path.join(theme, '.git'))
                 os.rmdir(tmpdir)
     try:
-        subprocess.check_call('webkit2png output/v7/{0}/index.html -W 1024 -H 768 -Fo screenshot'.format(theme), stdout=subprocess.PIPE, shell=True)
-        subprocess.check_call('convert screenshot-full.png output/v7/{0}.jpg && rm screenshot-full.png'.format(theme), stdout=subprocess.PIPE, shell=True)
+        subprocess.check_call('phantomjs scripts/take_screenshot.js output/v7/{0}/index.html 1024 768 output/v7/{0}.jpg'.format(theme), stdout=subprocess.PIPE, shell=True)
     except subprocess.CalledProcessError:
         subprocess.check_call('capty output/v7/{0}/index.html output/v7/{0}.jpg'.format(theme), stdout=subprocess.PIPE, shell=True)
 

--- a/scripts/take_screenshot.js
+++ b/scripts/take_screenshot.js
@@ -1,0 +1,46 @@
+var fs = require('fs');
+var page = require('webpage').create();
+var system = require('system');
+
+// Simple error checking
+var arg_count = system.args.length - 1;
+if (arg_count < 4 || arg_count > 5) {
+  console.log('Usage: offline_screenshot.js HTML_FILE WIDTH HEIGHT IMAGE_PATH');
+  phantom.exit(1);
+}
+
+// Extract arguments
+var source_path = system.args[1];
+var window_width = system.args[2];
+var window_height = system.args[3];
+var destination_image_path = system.args[4];
+
+var fullpath = fs.workingDirectory + fs.separator + source_path;
+console.log('Screenshot source: ' + fullpath);
+
+// Screen dimensions
+page.viewportSize = { 
+  width: window_width, 
+  height: window_height 
+};
+
+// Open page
+page.open(fullpath, function() {
+  //////////////////////
+  // To prevent some pages from being transparent
+  // ref: https://uggedal.com/journal/phantomjs-default-background-color/
+  page.evaluate(function() {
+    var style = document.createElement('style'),
+        text = document.createTextNode('body { background: #fff }');
+    style.setAttribute('type', 'text/css');
+    style.appendChild(text);
+    document.head.insertBefore(style, document.head.firstChild);
+  });
+  //////////////////////
+
+  // Take the screenshot
+  // ref: http://phantomjs.org/api/webpage/method/render.html#quality
+  page.render(destination_image_path, {quality: '70'});
+  phantom.exit(0);
+});
+


### PR DESCRIPTION
Changing theme screenshot tool from webkit2png to phantomjs
Adding a script to take the screenshot

**NOTE: It is assumed that 'phantomjs' is present on system PATH**.

Tested with PhantomJS version 2.1.1 on an Ubuntu 16.04 host.
