### PR TITLE
Adding bullets

### DIFF
--- a/v7/material-theme/assets/css/theme.css
+++ b/v7/material-theme/assets/css/theme.css
@@ -206,7 +206,7 @@ span.vcard img.img-circle {
 
  ul > li {
      list-style: disc;
-     margin-top:3px
+     margin-top: 3px
  }
  
  ul {

--- a/v7/material-theme/assets/css/theme.css
+++ b/v7/material-theme/assets/css/theme.css
@@ -204,9 +204,14 @@ span.vcard img.img-circle {
     margin: 20px;
 }
 
-ul > li {
-    list-style: none;
-}
+ ul > li {
+     list-style: disc;
+     margin-top:3px
+ }
+ 
+ ul {
+    padding-left: 25px;
+ } 
 
 .postlist a.reference > i {
     position: relative;


### PR DESCRIPTION
This restores the missing bullets found in Google's Material Theme docs.

Fixes #109 