### PR TITLE
Make the material-theme a little more mobile friendly:

### DIFF
--- a/v7/material-theme/assets/css/theme.css
+++ b/v7/material-theme/assets/css/theme.css
@@ -96,6 +96,28 @@ h2 {
     outline: 0;
 }
 
+
+/* NOTE(josh): If the screen is small enough that we wont use columns anymore,
+   then we'll want the navigation menu items to flow across the top of the page
+   rather than being spaced out and vertical. */
+@media (max-width: 767px) {
+
+  .menu ul {
+    margin: 10px 0;
+  }
+
+  .menu ul li a {
+    padding: 0 0 0 30px;
+    display: inline-block;
+    outline: 0;
+  }
+
+  .menu ul li {
+    display: inline;
+  }
+
+}
+
 /* articles */
 article > header span > a {
     color: #333;
@@ -170,19 +192,6 @@ span.vcard img.img-circle {
     min-height: 75%;
 }
 
-.posts-material {
-    position: absolute;
-    top: 0px;
-    right: 0px;
-    z-index: 4;
-    padding: 0px;
-    overflow: auto;
-}
-
-.posts-material> div {
-    padding: 64px 5px 0px;
-}
-
 .post-material, .content-material > article, .content-material > .page {
     opacity: 1;
     transform: translateY(0px);
@@ -196,12 +205,46 @@ span.vcard img.img-circle {
     border: 0px none;
 }
 
+
+/* NOTE(josh): If the screen is very small, then we don't want to waste
+   screen real-estate on the extra layers of padding.*/
+@media (max-width: 767px) {
+
+  .posts-material, .content-material{
+    padding: 0px;
+  }
+
+}
+
+/* NOTE(josh): we only want the posts column to overflow the title bar if the
+   screen is big enough to put the posts and navigation next to each other.*/
+@media (min-width: 768px) {
+
+  .posts-material {
+    position: absolute;
+    top: 0px;
+    right: 0px;
+    z-index: 4;
+    padding: 0px;
+    overflow: auto;
+  }
+
+  .posts-material> div {
+    padding: 64px 5px 0px;
+  }
+
+}
+
 .search-form {
     z-index: 10;
 }
 
 .btn-footer {
+    position: absolute;
+    left: 22px;
+    bottom: 22px;
     margin: 20px;
+    z-index: 5;
 }
 
  ul > li {
@@ -237,3 +280,4 @@ div.admonition {
     border: 0px solid transparent;
     box-shadow: 0px 8px 17px 0px rgba(0, 0, 0, 0.2), 0px 6px 20px 0px rgba(0, 0, 0, 0.19)
 }
+

--- a/v7/material-theme/assets/css/theme.css
+++ b/v7/material-theme/assets/css/theme.css
@@ -34,6 +34,26 @@ h2 {
     padding-left: 35px;
 }
 
+#hamburger {
+    background-color: #FFF;
+    color: #009688;
+    font-size: 1.5em;
+    font-weight: 400;
+    position: absolute;
+    background-color: #FFF;
+    display: none;
+    bottom: 10px;
+    right: 20px;
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-bottom: 4px;
+    padding-top: 4px;
+}
+
+#hamburger:hover {
+    text-decoration: none;
+}
+
 .header-panel div {
     position: relative;
     height: 100%;
@@ -96,10 +116,6 @@ h2 {
     outline: 0;
 }
 
-.menu .icon {
-    display: none;
-}
-
 @media (max-width: 767px) {
     .menu ul {
         margin: 10px 0;
@@ -118,17 +134,8 @@ h2 {
         display: block;
     }
 
-    .menu ul .icon {
-        display: block;
-        float: right;
-        margin-right: 20px;
-    }
-
-    .menu ul.responsive .icon {
-        display: block;
-        position: absolute;
-        right: 0;
-        top: 10px;
+    #hamburger {
+        display: inline;
     }
 }
 
@@ -251,7 +258,6 @@ span.vcard img.img-circle {
     left: 22px;
     bottom: 22px;
     margin: 20px;
-    z-index: 5;
 }
 
  ul > li {

--- a/v7/material-theme/assets/css/theme.css
+++ b/v7/material-theme/assets/css/theme.css
@@ -96,27 +96,42 @@ h2 {
     outline: 0;
 }
 
-
-/* NOTE(josh): If the screen is small enough that we wont use columns anymore,
-   then we'll want the navigation menu items to flow across the top of the page
-   rather than being spaced out and vertical. */
-@media (max-width: 767px) {
-
-  .menu ul {
-    margin: 10px 0;
-  }
-
-  .menu ul li a {
-    padding: 0 0 0 30px;
-    display: inline-block;
-    outline: 0;
-  }
-
-  .menu ul li {
-    display: inline;
-  }
-
+.menu .icon {
+    display: none;
 }
+
+@media (max-width: 767px) {
+    .menu ul {
+        margin: 10px 0;
+    }
+
+    .menu ul li a {
+        display: block;
+        padding: 10px 0 10px 50px;
+    }
+
+    .menu ul li {
+        display: none;
+    }
+
+    .menu ul.responsive li {
+        display: block;
+    }
+
+    .menu ul .icon {
+        display: block;
+        float: right;
+        margin-right: 20px;
+    }
+
+    .menu ul.responsive .icon {
+        display: block;
+        position: absolute;
+        right: 0;
+        top: 10px;
+    }
+}
+
 
 /* articles */
 article > header span > a {
@@ -206,33 +221,25 @@ span.vcard img.img-circle {
 }
 
 
-/* NOTE(josh): If the screen is very small, then we don't want to waste
-   screen real-estate on the extra layers of padding.*/
 @media (max-width: 767px) {
-
-  .posts-material, .content-material{
-    padding: 0px;
-  }
-
+    .posts-material, .content-material{
+        padding: 0px;
+    }
 }
 
-/* NOTE(josh): we only want the posts column to overflow the title bar if the
-   screen is big enough to put the posts and navigation next to each other.*/
 @media (min-width: 768px) {
+    .posts-material {
+        position: absolute;
+        top: 0px;
+        right: 0px;
+        z-index: 4;
+        padding: 0px;
+        overflow: auto;
+    }
 
-  .posts-material {
-    position: absolute;
-    top: 0px;
-    right: 0px;
-    z-index: 4;
-    padding: 0px;
-    overflow: auto;
-  }
-
-  .posts-material> div {
-    padding: 64px 5px 0px;
-  }
-
+    .posts-material> div {
+        padding: 64px 5px 0px;
+    }
 }
 
 .search-form {
@@ -280,4 +287,3 @@ div.admonition {
     border: 0px solid transparent;
     box-shadow: 0px 8px 17px 0px rgba(0, 0, 0, 0.2), 0px 6px 20px 0px rgba(0, 0, 0, 0.19)
 }
-

--- a/v7/material-theme/templates/base.tmpl
+++ b/v7/material-theme/templates/base.tmpl
@@ -41,6 +41,9 @@
                 <ul>
                     {{ base.html_navigation_links() }}
                     {{ template_hooks['menu']() }}
+                    <li class="icon">
+                        <a href="javascript:void(0);" onclick="menuToggle();">&#9776;</a>
+                    </li>
                 </ul>
 
                 <ul>

--- a/v7/material-theme/templates/base.tmpl
+++ b/v7/material-theme/templates/base.tmpl
@@ -31,6 +31,9 @@
                     </a>
             </h1>
           </div>
+          <div class="col-xs-9">
+            <a id="hamburger" class="btn btn-raised" href="javascript:void(0);" onclick="menuToggle();">&#9776;</a>
+          </div>
         </div>
       </div><!-- /.container-fluid -->
 </nav>
@@ -41,9 +44,6 @@
                 <ul>
                     {{ base.html_navigation_links() }}
                     {{ template_hooks['menu']() }}
-                    <li class="icon">
-                        <a href="javascript:void(0);" onclick="menuToggle();">&#9776;</a>
-                    </li>
                 </ul>
 
                 <ul>
@@ -63,6 +63,9 @@
                 </div>
             </div>
         </div>
+        <button class="btn btn-fab btn-raised btn-material-green btn-footer" data-toggle="modal" data-target="#footer-dialog">
+            <i class="mdi-communication-message"></i>
+        </button>
         <div id="footer-dialog" class="modal fade" tabindex="-1">
           <div class="modal-dialog">
             <div class="modal-content">
@@ -94,11 +97,7 @@
             {% endif %}
         </div>
         {% if social_links %}
-        <div class="kc_fab_wrapper">
-            <button class="btn btn-fab btn-raised btn-material-green btn-footer" data-toggle="modal" data-target="#footer-dialog">
-            <i class="mdi-communication-message"></i>
-            </button>
-        </div>
+        <div class="kc_fab_wrapper"></div>
         {% endif %}
 </div>
 

--- a/v7/material-theme/templates/base.tmpl
+++ b/v7/material-theme/templates/base.tmpl
@@ -37,13 +37,13 @@
 
 <div class="container-fluid main" id="content" role="main">
         <div class="row">
-            <nav  class="col-xs-3 menu">
+            <nav  class="col-xs-12 col-sm-3 menu">
                 <ul>
                     {{ base.html_navigation_links() }}
                     {{ template_hooks['menu']() }}
                 </ul>
 
-                <ul class="nav navbar-nav">
+                <ul>
                     {% block belowtitle %}
                     {% if translations|length > 1 %}
                         <li>{{ base.html_translations() }}</li>
@@ -54,15 +54,12 @@
             </nav>
 
             {{ template_hooks['page_header']() }}
-            <div class="posts-material col-xs-9">
+            <div class="posts-material col-xs-12 col-sm-9">
                 <div class="col-xs-12 col-md-11 content-material">
                 {% block content %}{% endblock %}
                 </div>
             </div>
         </div>
-        <button class="btn btn-fab btn-raised btn-material-green btn-footer" data-toggle="modal" data-target="#footer-dialog">
-            <i class="mdi-communication-message"></i>
-        </button>
         <div id="footer-dialog" class="modal fade" tabindex="-1">
           <div class="modal-dialog">
             <div class="modal-content">
@@ -94,9 +91,14 @@
             {% endif %}
         </div>
         {% if social_links %}
-        <div class="kc_fab_wrapper"></div>
+        <div class="kc_fab_wrapper">
+            <button class="btn btn-fab btn-raised btn-material-green btn-footer" data-toggle="modal" data-target="#footer-dialog">
+            <i class="mdi-communication-message"></i>
+            </button>
+        </div>
         {% endif %}
 </div>
+
 
 {{ base.late_load_js() }}
     <script>$('a.image-reference:not(.islink) img:not(.islink)').parent().colorbox({rel:"gal",maxWidth:"100%",maxHeight:"100%",scalePhotos:true});</script>

--- a/v7/material-theme/templates/base_helper.tmpl
+++ b/v7/material-theme/templates/base_helper.tmpl
@@ -136,9 +136,15 @@ lang="{{ lang }}">
             });
 
             $(window).on("resize", function() {
-                $("html, body").height($(window).height());
-                $(".main, .menu").height($(window).height() - $(".header-panel").outerHeight() - 76 ); // footer margin: $("footer.footer").outerHeight()
-                $(".posts-material").height($(window).height());
+                if($(window).width() > 767) {
+                  $("html, body").height($(window).height());
+                  $(".main, .menu").height($(window).height() - $(".header-panel").outerHeight() - 76 );
+                  $(".posts-material").height($(window).height());
+                } else {
+                  $("html, body").css('height', '');
+                  $(".main, .menu").css('height', '');
+                  $(".posts-material").css('height', '');
+                }
             }).trigger("resize");
         </script>
 {% endmacro %}

--- a/v7/material-theme/templates/base_helper.tmpl
+++ b/v7/material-theme/templates/base_helper.tmpl
@@ -146,6 +146,10 @@ lang="{{ lang }}">
                   $(".posts-material").css('height', '');
                 }
             }).trigger("resize");
+
+            function menuToggle() {
+                $("nav.menu, ul").toggleClass('responsive', '');
+            }
         </script>
 {% endmacro %}
 


### PR DESCRIPTION
In the smallest of the bootstrap breakpoints:

1. use a single column layout, rather than a two column layout
2. make the navigation menu items inline-block so they form a
   horizontal menu across the top of the page
3. remove padding from the content div
4. don't scroll posts separately from the "background" of the page,
   leave it all as one linear stream

The comments probably aren't desirable and I didn't even check on style issues... but if the change is desirable I'd be happy to clean up this patch.