### PR TITLE
Re-center listings without line numbers (fixes #155 regression)

### DIFF
--- a/v7/hyde/assets/css/poole.css
+++ b/v7/hyde/assets/css/poole.css
@@ -473,6 +473,6 @@ a.pagination-item:hover {
   }
 }
 
-pre.code.literal-block {
+td.code pre.code.literal-block {
     margin-left: 0;
 }


### PR DESCRIPTION
@ralsina what do you think?

# Before
![hyde_before](https://user-images.githubusercontent.com/1577132/40323531-ee3674b2-5d35-11e8-9fdf-fd1a9805c252.png)

# After
![hyde_after](https://user-images.githubusercontent.com/1577132/40323535-f4106e88-5d35-11e8-97fd-eaf1a5c482a1.png)
