### PR TITLE
[hyde theme] Fix viewport zoom for mobile devices

### DIFF
--- a/v7/hyde/templates/base_helper.tmpl
+++ b/v7/hyde/templates/base_helper.tmpl
@@ -27,7 +27,7 @@ lang="{{ lang }}">
     {% if description %}
     <meta name="description" content="{{ description|e }}">
     {% endif %}
-    <meta name="viewport" content="width=device-width">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     {% if title == blog_title %}
         <title>{{ blog_title|e }}</title>
     {% else %}


### PR DESCRIPTION
Hi!

The hyde theme has a broken default zoom level regarding mobile devices at the moment. Here are screenshots before and after the fix from a Huawei P10 Lite. Please consider the fix.

# Before — after
![nikola_hyde_viewport_zoom_before](https://user-images.githubusercontent.com/1577132/40626944-1b49e8cc-62bc-11e8-81d6-adc6ad151181.png) ![nikola_hyde_viewport_zoom_after](https://user-images.githubusercontent.com/1577132/40626950-1ed0a292-62bc-11e8-8c52-36c8976b3dc9.png)

Thanks and best, Sebastian