### PR TITLE
Upgrade Google Fonts url to https

### DIFF
--- a/v8/hyde/templates/base_helper.tmpl
+++ b/v8/hyde/templates/base_helper.tmpl
@@ -117,7 +117,7 @@ lang="{{ lang }}">
         <link href="/assets/css/nikola_ipython.css" rel="stylesheet" type="text/css">
     {% endif %}
 
-        <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
 
 {% endmacro %}
 


### PR DESCRIPTION
This way we avoid "mixed content" warnings on HTTPS sites that wouldn't load the fonts.