### PR TITLE
Added class for inline literal to template zen

### DIFF
--- a/v8/zen/assets/css/theme.css
+++ b/v8/zen/assets/css/theme.css
@@ -934,6 +934,10 @@ pre.code {
   max-height: 340px;
   overflow-y: scroll;
 }
+.docutils.literal {
+  font-family: monospace;
+  background-color: #EEEEEE;
+}
 .backlink {
   margin-top: 6px;
 }

--- a/v8/zen/less/code.less
+++ b/v8/zen/less/code.less
@@ -66,3 +66,9 @@ pre {
   max-height: 340px;
   overflow-y: scroll;
 }
+
+// Enable inline literal
+.docutils.literal {
+  font-family: monospace;
+  background-color: #EEEEEE;
+}


### PR DESCRIPTION
Added class `docutils literal` for ``inline literal``

this picture is before the changes

![zen-old](https://user-images.githubusercontent.com/1020887/67138362-59b9da80-f218-11e9-95cc-7dedcefa50af.png)

And this is with the change

![zen-new](https://user-images.githubusercontent.com/1020887/67138364-62121580-f218-11e9-858e-bfdc0a6c7802.png)
