### PR TITLE
[material-theme] Set width for img tag to 100% to make images responsive

### DIFF
--- a/v8/material-theme/assets/css/theme.css
+++ b/v8/material-theme/assets/css/theme.css
@@ -282,6 +282,10 @@ img.thumbnail {
     padding: 0px;
 }
 
+img {
+    width: 100%;
+}
+
 @media only screen and (max-width: 990px) {
     .source-button > a {
         top:35px;


### PR DESCRIPTION
closes #182 