### PR TITLE
material-theme: Simplify post's available translations retrieving.

### DIFF
--- a/v8/material-theme/templates/post_header.tmpl
+++ b/v8/material-theme/templates/post_header.tmpl
@@ -12,8 +12,8 @@
     {% if post.translated_to|length > 1 %}
         <div class="metadata posttranslations translations">
             <h3 class="posttranslations-intro">{{ messages("Also available in:") }}</h3>
-            {% for langname in translations.keys() %}
-                {% if langname != lang and post.is_translation_available(langname) %}
+            {% set available_languages = post.translated_to|reject("eq", lang)|sort %}
+            {% for langname in available_languages %}
                 <p><a href="{{ post.permalink(langname) }}" rel="alternate" hreflang="{{ langname }}">{{ messages("LANGUAGE", langname) }}</a></p>
                 {% endif %}
             {% endfor %}


### PR DESCRIPTION
Instead of previous loop, iterating over all translated languages
and displaying each lang. after some tests, we now proceed in 2 steps:

1. computing available languages first, before iterating,
   and filter them at this step;
2. iterating over previous result, and displaying links to translated
   posts.

This allows use of all loop variables provided by Jinja2, notably
loop.first and loop.last, with now correct values
(previous loop, as filtering list elements inside its body, forbid
usage of them).
Moreover, this better allows modifying (e.g. by a child/sub-theme)
HTML tags structure for displaying the list of translated posts links.
Last, this change use more Jinja "expected way-to-do" and less
programming idioms, and should potentially be more "designers friendly".