### PR TITLE
[hybrid] some more colour presets

### DIFF
--- a/v8/hybrid/assets/css/hybrid.css
+++ b/v8/hybrid/assets/css/hybrid.css
@@ -121,12 +121,63 @@ a.sidebar-nav-item.textonly:focus {
   text-decoration: underline;
 }
 
-/* subtheme */
+/*
+ * Themes
+ *
+ * The original Hyde theme includes optional themes to color the sidebar and links.
+ * The following flavours provide additional darker colors for the Hybrid theme.
+ */
+
+/* Petrol */
+.theme-hybrid-01 .hsidebar {
+  background-color: #2d4752;
+}
+.theme-hybrid-01 .content a,
+.theme-hybrid-01 .related-posts li a:hover {
+  color: #2d4752;
+}
+
+/* Dark Red */
+.theme-hybrid-02 .hsidebar {
+  background-color: #760009;
+}
+.theme-hybrid-02 .content a,
+.theme-hybrid-02 .related-posts li a:hover {
+  color: #760009;
+}
+
+/* Forest */
+.theme-hybrid-03 .hsidebar {
+  background-color: #004c01;
+}
+.theme-hybrid-03 .content a,
+.theme-hybrid-03 .related-posts li a:hover {
+  color: #004c01;
+}
+
+/* Eggplant */
+.theme-hybrid-04 .hsidebar {
+  background-color: #4c0033;
+}
+.theme-hybrid-04 .content a,
+.theme-hybrid-04 .related-posts li a:hover {
+  color: #4c0033;
+}
+
+/* Orange */
+.theme-hybrid-05 .hsidebar {
+  background-color: #9e4000;
+}
+.theme-hybrid-05 .content a,
+.theme-hybrid-05 .related-posts li a:hover {
+  color: #9e4000;
+}
+
+/* custom subtheme */
 .theme-custom .hsidebar {
   background-color: #070512;
 }
-.theme-custom .content a:not([class*="btn-"]),
+.theme-custom .content a,
 .theme-custom .related-posts li a:hover {
   color: #1582ae;
 }
-

--- a/v8/hybrid/conf.py.sample
+++ b/v8/hybrid/conf.py.sample
@@ -13,6 +13,11 @@ NAVIGATION_LINKS = {
 THEME_CONFIG = {
     DEFAULT_LANG: {
         # "hyde_subtheme": "theme-custom",
+        # "hyde_subtheme": "theme-hybrid-01", # petrol
+        # "hyde_subtheme": "theme-hybrid-02", # dark red
+        # "hyde_subtheme": "theme-hybrid-03", # forest
+        # "hyde_subtheme": "theme-hybrid-04", # eggplant
+        # "hyde_subtheme": "theme-hybrid-05", # dark orange
         # "hyde_subtheme": "theme-base-08", # red
         # "hyde_subtheme": "theme-base-09", # orange
         # "hyde_subtheme": "theme-base-0a", # yellow

--- a/v8/hyde/assets/css/hyde.css
+++ b/v8/hyde/assets/css/hyde.css
@@ -218,7 +218,7 @@ a.sidebar-nav-item:focus {
  * within blog posts. To use, add the class of your choosing to the `body`.
  */
 
-/* Base16 (http://chriskempson.github.io/base16/#default) */
+/* Base16 (http://chriskempson.com/projects/base16/) */
 
 /* Red */
 .theme-base-08 .hsidebar {


### PR DESCRIPTION
Hey there.

I added some colour subthemes to the Hybrid theme as I've never really liked the Hyde subthemes. Available options were included in the conf.py.example.

You can have a look at the options in [this blog post](https://log.bahnfreikartoffelbrei.de/posts/hybrid-theme-colours/).

Regards.