### PR TITLE
[zen] add a small left margin to listtitle

### DIFF
--- a/v8/zen/assets/css/theme.css
+++ b/v8/zen/assets/css/theme.css
@@ -1080,3 +1080,6 @@ article.post-text .entry-content .figure .caption {
 article.post-text + article.post-text {
   margin-top: 48px;
 }
+a.listtitle {
+  margin-left: 6px;
+}


### PR DESCRIPTION
At the moment there's no space between <listdate> and .listtitle

Example: https://www.adamprocio.cz/2022/

This change makes the list prettier.