### PR TITLE
[zen] use img settings for svg also

### DIFF
--- a/v8/zen/assets/css/theme.css
+++ b/v8/zen/assets/css/theme.css
@@ -159,7 +159,8 @@ sup {
 sub {
   bottom: -0.25em;
 }
-img {
+img,
+svg {
   /* Responsive images (ensure images don't scale beyond their parents) */
   max-width: 100%;
   /* Part 1: Set a maxium relative to the parent */


### PR DESCRIPTION
As you can see, `<svg>`'s don't get styled at the moment, this change fixes that. SVG's are output of the graphviz plugin, as seen here: https://www.adamprocio.cz/pages/adam-procio/