### PR TITLE
hyde: Fix `h1`-`a`-`h1`-`a` duplication with `html_site_title`

### DIFF
--- a/v7/hyde/templates/base.tmpl
+++ b/v7/hyde/templates/base.tmpl
@@ -15,11 +15,7 @@
     <div class="hsidebar">
         <div class="container sidebar-sticky">
             <div class="sidebar-about">
-              <h1>
-                <a href="{{ abs_link(_link("root", None, lang)) }}">
-                  {{ header.html_site_title() }}
-                </a>
-              </h1>
+            {{ header.html_site_title() }}
             {{ header.html_site_description() }}
             </div>
             {{ header.html_navigation_links() }}

--- a/v8/hyde/templates/base.tmpl
+++ b/v8/hyde/templates/base.tmpl
@@ -15,11 +15,7 @@
     <div class="hsidebar">
         <div class="container sidebar-sticky">
             <div class="sidebar-about">
-              <h1>
-                <a href="{{ abs_link(_link("root", None, lang)) }}">
-                  {{ header.html_site_title() }}
-                </a>
-              </h1>
+            {{ header.html_site_title() }}
             {{ header.html_site_description() }}
             </div>
             {{ header.html_navigation_links() }}


### PR DESCRIPTION
### Before
```html
<h1>
  <a href="https://host.invalid/">
    <h1 id="brand">
      <a href="https://host.invalid/" title="Some site" rel="home">
        <span id="blog-title">Some site</span>
      </a>
    </h1>
  </a>
</h1>
```

### After

```html
<h1 id="brand">
  <a href="https://host.invalid/" title="Some site" rel="home">
    <span id="blog-title">Some site</span>
  </a>
</h1>
```

### In the wild

#### Broken

https://themes.getnikola.com/v8/hyde/demo/

<img width="749" height="247" alt="demo_site" src="https://github.com/user-attachments/assets/859f69e5-ecde-4711-b241-ce1bfb9a0de0" />

#### Fixed

https://blog.hartwork.org/



CC @StanFromIreland @hannob